### PR TITLE
fix: build and run on macOS

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ install_manifest.txt
 
 # Executables
 *.exe
-ewr
 Release
 
 # Editor Settings

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ install_manifest.txt
 
 # Executables
 *.exe
+ewr
 Release
 
 # Editor Settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ else()
     pkg_check_modules(LIBCURL REQUIRED libcurl)
     
     target_include_directories(ewr_core PRIVATE ${LIBUSB_INCLUDE_DIRS} ${LIBCURL_INCLUDE_DIRS})
+    # Homebrew keeps its libs outside the default linker search path.
+    target_link_directories(ewr_core PUBLIC ${LIBUSB_LIBRARY_DIRS} ${LIBCURL_LIBRARY_DIRS})
     target_link_libraries(ewr_core PRIVATE ${LIBUSB_LIBRARIES} ${LIBCURL_LIBRARIES})
 endif()
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # EWR (Epson Waste Reset)
-![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux-blue)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-blue)
 ![C++](https://img.shields.io/badge/language-C++17-orange)
 ![License](https://img.shields.io/badge/license-Apache_License_2.0-green)
 
@@ -12,20 +12,21 @@ EWR bypasses the need to pay for sketchy third-party reset keys (like WIC Reset)
 * **OTA Database Sync:** Automatically fetches a massive, continuously updated database of printer offsets and keys on startup using native OS APIs (Zero bloat).
 * **Cross-Platform Core:**
   * **Windows:** Uses 100% native Win32 `SetupAPI` and robust Asynchronous `OVERLAPPED` I/O to safely drain the Windows Print Spooler buffers. Zero custom drivers required.
-  * **Linux:** Uses `libusb` to automatically detach the kernel driver (CUPS) for exclusive, raw hardware access.
+  * **Linux & macOS:** Uses `libusb` to automatically detach the kernel driver (CUPS) for exclusive, raw hardware access.
 * **Zero Hardcoded PIDs:** Automatically scans your OS USB tree to find connected Epson printers.
 * **Replay Fallback:** If your printer is brand new and not in the database yet, EWR can still dynamically parse and execute raw Wireshark dumps (stripping USBPcap headers automatically).
 
 ### Prerequisites (For Building from Source)
 * **Windows:** Visual Studio with MSVC C++ build tools.
 * **Linux (Arch/Debian):** `cmake`, `gcc`, `pkgconf`, `libusb-1.0-dev`, and `libcurl4-openssl-dev`.
+* **macOS:** `brew install cmake libusb curl pkgconf`
 
 ## Usage
 
 1. Ensure your Epson printer is turned on and connected to your computer via USB.
 2. Run the executable:
    * **Windows:** Double-click `ewr.exe`
-   * **Linux:** `sudo ./ewr` *(Raw USB access requires root)*
+   * **Linux / macOS:** `sudo ./ewr` *(Raw USB access requires root)*
 3. **Note:** On the very first run, EWR requires an internet connection to download the latest printer database. Afterward, it works entirely offline.
 4. Type the number corresponding to your printer and hit Enter.
 5. Wait for the `SUCCESS` message, then **turn your printer off and back on using its physical power button** to commit the EEPROM changes to the motherboard.

--- a/src/usb_linux.cpp
+++ b/src/usb_linux.cpp
@@ -1,7 +1,13 @@
 #include "ewr/usb.h"
 #include "ewr/executor.h"
 #include "ewr/generator.h"
+// Distro packages install the header under libusb-1.0/; Homebrew relies on the
+// pkg-config include dir already pointing inside that folder.
+#if __has_include(<libusb-1.0/libusb.h>)
 #include <libusb-1.0/libusb.h>
+#else
+#include <libusb.h>
+#endif
 #include <algorithm>
 #include <fstream>
 #include <iomanip>
@@ -159,7 +165,7 @@ namespace ewr {
 
             if (logFile.is_open())
             {
-                logFile << "EWR Hardware Trace Log (Linux)\n";
+                logFile << "EWR Hardware Trace Log (libusb)\n";
                 logFile << "==================================================\n";
                 logFile << "Target VID: 0x04B8 | PID: 0x" << std::hex << desc.idProduct << std::dec << "\n";
                 logFile << "Target Interface: " << selected_interface << (found_printer_class ? " (Printer Class)" : " (Vendor-Specific Class)") << "\n";
@@ -211,7 +217,7 @@ namespace ewr {
 
     bool ExecutePayloadSequence(EwrDeviceHandle hPrinter, const std::vector<std::vector<unsigned char>>& sequence)
     {
-        std::cout << "\nExecuting universal Linux hardware state machine..." << std::endl;
+        std::cout << "\nExecuting universal libusb hardware state machine..." << std::endl;
         std::cout << "[i] Saving hardware trace to ewr_trace.log for diagnostics." << std::endl;
 
         LinuxDeviceContext* ctx = static_cast<LinuxDeviceContext*>(hPrinter);


### PR DESCRIPTION
## Summary

EWR already compiles its Linux libusb path on macOS — two Homebrew-specific path
assumptions were the only thing standing in the way. This PR fixes both and turns on
the macOS CI job that this repo already had the dependency step for.

Verified end to end on real hardware, not just a green build (details below).

## The two build failures

**1. Header include (`src/usb_linux.cpp`)**

`#include <libusb-1.0/libusb.h>` assumes the distro layout, where `/usr/include` is on
the default search path. Homebrew installs into a prefix that isn't, and the `-I` that
`pkg-config` hands back already points *inside* `include/libusb-1.0` — so the extra
prefix resolves to nothing:

```
src/usb_linux.cpp:4:10: fatal error: 'libusb-1.0/libusb.h' file not found
```

Fixed with `__has_include` so both layouts work, no platform `#ifdef` needed.

**2. Linker search path (`CMakeLists.txt`)**

`pkg_check_modules` exports `LIBUSB_LIBRARIES` as the bare name `usb-1.0` and keeps the
directory in `LIBUSB_LIBRARY_DIRS`. On Linux that dir is already on the default path; on
macOS it's `/opt/homebrew/Cellar/libusb/*/lib` and the link fails with unresolved symbols.

Note this must be `PUBLIC`: `ewr_core` is a STATIC library, so `PRIVATE` link directories
do not propagate to the `ewr` executable and the link still fails. (A cleaner alternative
is `pkg_check_modules(... IMPORTED_TARGET ...)` with `PkgConfig::LIBUSB` — happy to switch
if you prefer that; I kept the diff minimal.)

## CI

`build-test-release.yml` already carries an `if: matrix.os == 'macos-latest'` step running
`brew install libusb curl pkgconfig`, but `macos-latest` was never in the matrix, so it
never ran. Added it — that job is red without the two fixes above and green with them.

## Hardware verification

macOS 15 arm64, AppleClang 21, libusb 1.0.30, **EPSON L220 Series** (PID `0x08d1`):

```
-> Packet  6 / 21 | EEPROM write verified (||:42:OK;).
-> Packet  9 / 21 | EEPROM write verified (||:42:OK;).
-> Packet 12 / 21 | EEPROM write verified (||:42:OK;).
-> Packet 15 / 21 | EEPROM write verified (||:42:OK;).
-> Packet 18 / 21 | EEPROM write verified (||:42:OK;).
-> Packet 21 / 21 | EEPROM write verified (||:42:OK;).

========================================
 SUCCESS! Turn the printer OFF, then ON.
========================================
```

All six EEPROM addresses in the L220 database entry (24, 25, 28, 29, 46, 30) reported
write verified. `ctest` also passes on macOS.

**`sudo` is required, same as Linux.** The class-aware interface selection from #9 picks
the printer-class interface, which macOS binds to a system driver. Probing both interfaces:

```
iface 0: class=255 (vendor-specific)  kernel_driver_active=0  claim=OK
iface 1: class=7   (printer class)    kernel_driver_active=1  claim=LIBUSB_ERROR_ACCESS
```

Unprivileged `libusb_detach_kernel_driver` returns `LIBUSB_ERROR_ACCESS`; under `sudo` it
returns OK and the claim succeeds. So the existing "Raw USB access requires root" guidance
covers macOS unchanged — README updated to say so.

## Also included

- README: platform badge, macOS build prerequisites, macOS usage line
- `.gitignore`: the non-Windows build drops the `ewr` binary in the repo root
  (`RUNTIME_OUTPUT_DIRECTORY`) and only `*.exe` was ignored
- Two log strings said "Linux" on a path that now also serves macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ksFPZNX2GxB7CWvh9PRbY
